### PR TITLE
Fix Markdown viewer initialization

### DIFF
--- a/src/main/resources/js/markdown-viewer.js
+++ b/src/main/resources/js/markdown-viewer.js
@@ -10,12 +10,18 @@ let shouldAutoScroll = true; // Flag to control auto-scrolling behavior
 const panelStates = {};
 let scrollTimeout = null;
 
-// Initialize when document is ready
-document.addEventListener('DOMContentLoaded', function() {
+// Initialize when document is ready or immediately if already loaded
+function initMarkdownViewer() {
     console.log('Markdown viewer JavaScript loaded');
     initializeScrollTracking();
     initCollapsiblePanels();
-});
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initMarkdownViewer);
+} else {
+    initMarkdownViewer();
+}
 
 // Initialize scroll tracking
 function initializeScrollTracking() {


### PR DESCRIPTION
## Summary
- ensure markdown viewer JS runs even when DOM is already loaded

## Testing
- `./gradlew test --no-daemon` *(fails: No IntelliJ Platform dependency found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f88133348330bbb02eee6ae91698