### PR TITLE
Implement TODO scanning feature

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,4 +17,4 @@
 - [ ] Bug: "Error executing Aider command: null" when aborting command
 - [ ] Feature: Add a way to add and manage simple custom user actions that execute a user defined prompt with
   preconfigured context files (make this configurable comparable to test creation)
-- [ ] Feature: find all TODOs in the files of the current context and add them to the prompt as in fix todos but also referencing each file 
+- [x] Feature: find all TODOs in the files of the current context and add them to the prompt as in fix todos but also referencing each file

--- a/src/main/kotlin/de/andrena/codingaider/actions/aider/AiderAction.kt
+++ b/src/main/kotlin/de/andrena/codingaider/actions/aider/AiderAction.kt
@@ -16,6 +16,7 @@ import de.andrena.codingaider.inputdialog.AiderMode
 import de.andrena.codingaider.services.AiderDialogStateService
 import de.andrena.codingaider.services.AiderIgnoreService
 import de.andrena.codingaider.services.FileDataCollectionService
+import de.andrena.codingaider.services.TodoPromptService
 import de.andrena.codingaider.settings.AiderSettings.Companion.getInstance
 
 
@@ -82,8 +83,10 @@ class AiderAction : AnAction() {
 
         fun collectCommandData(dialog: AiderInputDialog, project: Project): CommandData {
             val settings = getInstance()
+            val prompt = project.service<TodoPromptService>()
+                .buildPrompt(dialog.getInputText(), dialog.getAllFiles())
             return CommandData(
-                message = dialog.getInputText(),
+                message = prompt,
                 useYesFlag = dialog.isYesFlagChecked(),
                 llm = dialog.getLlm().name,
                 additionalArgs = dialog.getAdditionalArgs(),
@@ -99,8 +102,9 @@ class AiderAction : AnAction() {
 
         fun collectCommandData(files: List<FileData>, message: String, project: Project, mode: AiderMode): CommandData {
             val settings = getInstance()
+            val prompt = project.service<TodoPromptService>().buildPrompt(message, files)
             return CommandData(
-                message = message,
+                message = prompt,
                 useYesFlag = settings.useYesFlag,
                 llm = settings.llm,
                 additionalArgs = settings.additionalArgs,

--- a/src/main/kotlin/de/andrena/codingaider/services/TodoPromptService.kt
+++ b/src/main/kotlin/de/andrena/codingaider/services/TodoPromptService.kt
@@ -1,0 +1,47 @@
+package de.andrena.codingaider.services
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import de.andrena.codingaider.command.FileData
+import java.io.File
+import java.nio.file.Paths
+
+/**
+ * Service that collects TODO comments from a list of files and augments a prompt
+ * with these TODOs referencing their source files.
+ */
+@Service(Service.Level.PROJECT)
+class TodoPromptService(private val project: Project) {
+
+    fun buildPrompt(basePrompt: String, files: List<FileData>): String {
+        val todosPerFile = collectTodos(files)
+        if (todosPerFile.isEmpty()) return basePrompt
+
+        val sb = StringBuilder(basePrompt.trimEnd())
+        if (sb.isNotEmpty()) sb.appendLine().appendLine()
+        sb.appendLine("Fix the following TODOs:")
+        todosPerFile.forEach { (filePath, todos) ->
+            val relativePath = project.basePath?.let { base ->
+                Paths.get(base).relativize(Paths.get(filePath)).toString()
+            } ?: filePath
+            sb.appendLine("- In $relativePath:")
+            todos.forEach { sb.appendLine(it.trim()) }
+            sb.appendLine()
+        }
+        return sb.toString().trimEnd()
+    }
+
+    fun collectTodos(files: List<FileData>): Map<String, List<String>> {
+        val todoMap = linkedMapOf<String, List<String>>()
+        files.forEach { fileData ->
+            val file = File(fileData.filePath)
+            if (file.exists() && file.isFile) {
+                val todos = file.readLines().filter { it.contains("TODO", ignoreCase = true) }
+                if (todos.isNotEmpty()) {
+                    todoMap[fileData.filePath] = todos
+                }
+            }
+        }
+        return todoMap
+    }
+}

--- a/src/test/kotlin/de/andrena/codingaider/services/TodoPromptServiceTest.kt
+++ b/src/test/kotlin/de/andrena/codingaider/services/TodoPromptServiceTest.kt
@@ -1,0 +1,52 @@
+package de.andrena.codingaider.services
+
+import com.intellij.openapi.project.Project
+import de.andrena.codingaider.command.FileData
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import java.nio.file.Files
+
+class TodoPromptServiceTest {
+    private lateinit var service: TodoPromptService
+    private lateinit var mockProject: Project
+
+    @BeforeEach
+    fun setUp() {
+        mockProject = mock(Project::class.java)
+        service = TodoPromptService(mockProject)
+    }
+
+    @Test
+    fun `collectTodos finds todos in files`() {
+        val tempDir = Files.createTempDirectory("todoTest")
+        val fileWithTodo = tempDir.resolve("A.kt").toFile().apply {
+            writeText("""
+                // TODO: fix this
+                fun a() {}
+            """.trimIndent())
+        }
+        val fileWithoutTodo = tempDir.resolve("B.kt").toFile().apply {
+            writeText("fun b() {}")
+        }
+        val files = listOf(FileData(fileWithTodo.absolutePath, false), FileData(fileWithoutTodo.absolutePath, false))
+        val result = service.collectTodos(files)
+
+        assertThat(result).containsKey(fileWithTodo.absolutePath)
+        assertThat(result[fileWithTodo.absolutePath]).isNotEmpty
+        assertThat(result).doesNotContainKey(fileWithoutTodo.absolutePath)
+    }
+
+    @Test
+    fun `buildPrompt appends todos to base prompt`() {
+        val tempFile = Files.createTempFile("C", ".kt").toFile()
+        tempFile.writeText("// TODO: implement")
+        val files = listOf(FileData(tempFile.absolutePath, false))
+
+        val result = service.buildPrompt("Base", files)
+
+        assertThat(result).contains("Base")
+        assertThat(result).contains("TODO: implement")
+    }
+}


### PR DESCRIPTION
## Summary
- add `TodoPromptService` for scanning TODO comments across context files
- integrate todo prompt augmentation into `AiderAction`
- test todo scanning logic
- mark TODO as complete in `TODO.md`

## Testing
- `./gradlew test` *(fails: No IntelliJ Platform dependency found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fc1698308330a92ebac9a6b807b0