### PR TITLE
Implement stash feature in input dialog

### DIFF
--- a/src/main/kotlin/de/andrena/codingaider/inputdialog/AiderContextView.kt
+++ b/src/main/kotlin/de/andrena/codingaider/inputdialog/AiderContextView.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.ui.IconManager
+import com.intellij.openapi.ui.Messages
 import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.treeStructure.Tree
@@ -321,6 +322,31 @@ class AiderContextView(
             val newPath = findUpdatedPath(path)
             tree.expandPath(newPath)
             tree.addSelectionPath(newPath)
+        }
+    }
+
+    fun stashSelectedFiles() {
+        val selectedFiles = getSelectedFiles()
+        if (selectedFiles.isEmpty()) return
+
+        val stashName = Messages.showInputDialog(
+            project,
+            "Enter a name for this stash (optional):",
+            "Stash Files",
+            Messages.getQuestionIcon()
+        ) ?: return
+
+        try {
+            persistentFileService.stashFiles(selectedFiles, stashName)
+            allFiles = allFiles.filterNot { it in selectedFiles }
+            persistentFiles = persistentFileService.getPersistentFiles()
+            selectedFilesChanged()
+        } catch (e: Exception) {
+            Messages.showErrorDialog(
+                project,
+                "Failed to stash files: ${'$'}{e.message}",
+                "Stash Error"
+            )
         }
     }
 

--- a/src/main/kotlin/de/andrena/codingaider/inputdialog/AiderContextViewPanel.kt
+++ b/src/main/kotlin/de/andrena/codingaider/inputdialog/AiderContextViewPanel.kt
@@ -8,6 +8,7 @@ import com.intellij.ui.LayeredIcon
 import com.intellij.util.ui.JBUI
 import de.andrena.codingaider.command.FileData
 import de.andrena.codingaider.services.AiderIgnoreService
+import com.intellij.openapi.ui.Messages
 import java.awt.BorderLayout
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
@@ -160,6 +161,20 @@ class AiderContextViewPanel(
                     )
                 ), aiderContextView
             )
+        })
+
+        add(object : AnAction(
+            "Stash Files", "Stash selected files", AllIcons.Vcs.ShelveSilent
+        ) {
+            override fun actionPerformed(e: AnActionEvent) {
+                aiderContextView.stashSelectedFiles()
+            }
+
+            override fun update(e: AnActionEvent) {
+                e.presentation.isEnabled = aiderContextView.getSelectedFiles().isNotEmpty()
+            }
+
+            override fun getActionUpdateThread() = ActionUpdateThread.BGT
         })
     }
 


### PR DESCRIPTION
## Summary
- add method to stash selected context files
- expose new `Stash Files` action in the input dialog toolbar

## Testing
- `./gradlew test` *(fails: No IntelliJ Platform dependency found)*

------
https://chatgpt.com/codex/tasks/task_e_6842900965d083308e0a361d0f0080cc